### PR TITLE
Enable Global Mean SST notebook in table of contents

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -34,7 +34,7 @@ project:
     - title: Aplicaciones científicas
       children:
         - file: notebooks/3.Aplicaciones/3.1.ENSO.ipynb
-#        - file: notebooks/3.Aplicaciones/3.2.Global-Mean-SST.ipynb
+        - file: notebooks/3.Aplicaciones/3.2.Global-Mean-SST.ipynb
         - file: notebooks/3.Aplicaciones/3.3.ERA5.ipynb
         - file: notebooks/3.Aplicaciones/3.4.QVPs.ipynb
         - file: notebooks/3.Aplicaciones/3.5.QPE.ipynb


### PR DESCRIPTION
Uncommented the 3.2.Global-Mean-SST.ipynb entry in myst.yml to make the notebook visible and accessible in the rendered book.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
